### PR TITLE
Fix escape string

### DIFF
--- a/qq.go
+++ b/qq.go
@@ -187,7 +187,7 @@ func qq(stdin io.Reader) ([][]string, error) {
 			if i > 0 {
 				s += `,`
 			}
-			s += `'` + strings.Replace(n, `'`, `\'`, -1) + `'`
+			s += `'` + strings.Replace(n, `'`, `''`, -1) + `'`
 		}
 		s += `)`
 		_, err = db.Exec(s)
@@ -200,7 +200,7 @@ func qq(stdin io.Reader) ([][]string, error) {
 			if i > 0 {
 				s += `,`
 			}
-			s += `'` + strings.Replace(n, `'`, `\'`, -1) + `'`
+			s += `'` + strings.Replace(n, `'`, `''`, -1) + `'`
 		}
 		s += `) values`
 		d := ``
@@ -222,7 +222,7 @@ func qq(stdin io.Reader) ([][]string, error) {
 				if renum.MatchString(col) {
 					d += col
 				} else {
-					d += `'` + strings.Replace(col, `'`, `\'`, -1) + `'`
+					d += `'` + strings.Replace(col, `'`, `''`, -1) + `'`
 				}
 			}
 			d += `)`

--- a/qq_test.go
+++ b/qq_test.go
@@ -115,6 +115,7 @@ func TestQQ(t *testing.T) {
 PID command
   1 /usr/bin/ls
   2 /usr/bin/grep
+  3 /usr/bin/php run.php --opt='1'
 `
 	*query = "select pid from stdin"
 	rows, err := qq(strings.NewReader(input))
@@ -122,7 +123,7 @@ PID command
 		t.Fatal(err)
 	}
 
-	if len(rows) != 2 {
+	if len(rows) != 3 {
 		t.Fatalf("rows should have two row: got %v", rows)
 	}
 
@@ -138,6 +139,10 @@ PID command
 		t.Fatalf("second result should be 2: got %v", rows[0][0])
 	}
 
+	if rows[2][0] != "3" {
+		t.Fatalf("second result should be 3: got %v", rows[0][0])
+	}
+
 	*query = "select command from stdin where pid = 2"
 	rows, err = qq(strings.NewReader(input))
 	if err != nil {
@@ -146,6 +151,16 @@ PID command
 
 	if rows[0][0] != "/usr/bin/grep" {
 		t.Fatalf("result should be '/usr/bin/grep': got %v", rows[0][0])
+	}
+
+	*query = "select command from stdin where pid = 3"
+	rows, err = qq(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rows[0][0] != "/usr/bin/php run.php --opt='1'" {
+		t.Fatalf("result should be '/usr/bin/php run.php --opt='1': got %v", rows[0][0])
 	}
 }
 


### PR DESCRIPTION
I got an error from `ps | qq -q "select pid from stdin"` while running `vagrant up`.
I figured out a single quote is something wrong.

```
 5739 ttys002    0:01.40 /usr/bin/python /usr/local/Cellar/ansible/1.9.4/libexec/bin/ansible-playbook --connection=ssh --timeout=30 --extra-vars=ansible_ssh_user='vagrant' --limit=all --inventory-file=provision/hosts --sudo -vvvv provisi
```
