### PR TITLE
Detect column types

### DIFF
--- a/qq.go
+++ b/qq.go
@@ -38,9 +38,7 @@ type Option struct {
 	Encoding  xenc.Encoding
 }
 
-var (
-	renum = regexp.MustCompile(`^[+-]?[1-9][0-9]*(\.[0-9]+)?(e-?[0-9]+)?$`)
-)
+var renum = regexp.MustCompile(`^[+-]?[1-9][0-9]*(\.[0-9]+)?(e-?[0-9]+)?$`)
 
 func readLines(r io.Reader) ([]string, error) {
 	var lines []string
@@ -144,6 +142,12 @@ func NewQQ(opt *Option) (*QQ, error) {
 	return &QQ{db, opt}, nil
 }
 
+const (
+	sqliteINTEGER = "INTEGER"
+	sqliteTEXT    = "TEXT"
+	sqliteREAL    = "REAL"
+)
+
 type column struct {
 	Name string
 	Type string
@@ -152,7 +156,7 @@ type column struct {
 func newColumn(name string) *column {
 	return &column{
 		Name: name,
-		Type: "INTEGER",
+		Type: sqliteINTEGER,
 	}
 }
 
@@ -245,15 +249,15 @@ func (qq *QQ) Import(r io.Reader, name string) error {
 				continue
 			}
 			colDef := cn[i]
-			if colDef.Type == "TEXT" {
+			if colDef.Type == sqliteTEXT {
 				continue
 			}
 			if matches := renum.FindStringSubmatch(col); len(matches) > 0 {
 				if matches[1] != "" || matches[2] != "" {
-					colDef.Type = "REAL"
+					colDef.Type = sqliteREAL
 				}
 			} else {
-				colDef.Type = "TEXT"
+				colDef.Type = sqliteTEXT
 			}
 		}
 	}

--- a/qq_test.go
+++ b/qq_test.go
@@ -427,3 +427,35 @@ PID:2	command:/usr/bin/grep
 		t.Fatalf("result should be '/usr/bin/grep': got %v", rows[0][0])
 	}
 }
+
+func TestColumsAndRows(t *testing.T) {
+	input := `
+int_key text_key      real_key
+1       1             15
+2       /usr/bin/grep 1.04
+2       10            300065
+`
+	qq, _ := NewQQ(&Option{})
+	cn, _, _ := qq.columnsAndRows(strings.NewReader(input))
+	out := make([]column, len(cn))
+	for i, c := range cn {
+		out[i] = *c
+	}
+	expect := []column{
+		{
+			Name: "int_key",
+			Type: sqliteINTEGER,
+		},
+		{
+			Name: "text_key",
+			Type: sqliteTEXT,
+		},
+		{
+			Name: "real_key",
+			Type: sqliteREAL,
+		},
+	}
+	if !reflect.DeepEqual(out, expect) {
+		t.Errorf("\n out =%+v\n want=%+v", out, expect)
+	}
+}


### PR DESCRIPTION
I made the mechanism to detect the SQLite column types, `INTEGER`, `REAL` or `TEXT`.
It is useful for aggregate function use etc.

I did it as default behavior, but I know it is a bit incompatible change, so if you think it it a problem, I can create new command line option for this behavior.